### PR TITLE
fix: remove version pinning to prevent missing packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,30 +11,30 @@ WORKDIR /app
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
-  gettext=0.21* \
-  python3-celery=5.2.6* \
+  gettext \
+  python3-celery \
   gosu \
   util-linux \
-  rsync=3.2.7* \
-  flex=2.6.4* \
-  bison=2:3.8.2* \
-  ninja-build=1.11* \
-  libjansson-dev=2.14* \
-  libjansson-doc=2.14* \
-  libjansson4=2.14* \
-  libpopt-dev=1.19* \
-  libpcre3-dev=2:8.39* \
-  pixz=1.0.7* \
-  libxml-parser-perl=2.46* \
-  build-essential=12.9* \
-  curl=7.88.1* \
-  libkrb5-dev=1.20.1* \
-  libffi-dev=3.4.4* \
-  libxml2-dev=2.9.14* \
-  libyaml-dev=0.2.5* \
-  libssl-dev=3.0.15* \
-  libglib2.0-dev=2.74.6* \
-  git=1:2.39.5* \
+  rsync \
+  flex \
+  bison \
+  ninja-build \
+  libjansson-dev \
+  libjansson-doc \
+  libjansson4 \
+  libpopt-dev \
+  libpcre3-dev \
+  pixz \
+  libxml-parser-perl \
+  build-essential \
+  curl \
+  libkrb5-dev \
+  libffi-dev \
+  libxml2-dev \
+  libyaml-dev \
+  libssl-dev \
+  libglib2.0-dev \
+  git \
   && rm -rf /var/lib/apt/lists/* \
   && cpan -T JSON
 


### PR DESCRIPTION
Unpinned package versions in apt-get install to avoid failures caused by outdated or unavailable version-specific packages in upstream mirrors.