### PR TITLE
fix(proxy): add missing port forwarding to Django application

### DIFF
--- a/nginx/templates/local/nginx.conf.template
+++ b/nginx/templates/local/nginx.conf.template
@@ -26,7 +26,9 @@ server {
     location ${URL_PREFIX}/ {
         proxy_pass http://django;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
         proxy_redirect off;
     }
 

--- a/nginx/templates/prod/nginx.conf.template
+++ b/nginx/templates/prod/nginx.conf.template
@@ -22,7 +22,9 @@ server {
     location ${URL_PREFIX}/ {
         proxy_pass http://django;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
         proxy_redirect off;
     }
 


### PR DESCRIPTION
The proxy configuration was not forwarding the port information to the django causing Django to generate URLs without the port component. This resulted in incorrect API URLs being returned to the frontend, breaking data fetching.

- Configure proxy to preserve port information in forwarded requests
- Ensure Django receives complete URL context for proper URL generation
- Fix frontend API calls that were failing due to malformed URLs