### PR TITLE
fix: change to python 3.12-slim-bookworm for base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ###########################################
 #         Base Python Image              #
 ###########################################
-FROM python:3.12-slim AS base
+FROM python:3.12-slim-bookworm AS base
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
`libpcre3-dev` is removed from debian trixie since it's outdated lib and replaced by `libpcre2-dev` but build fails on `amd64` for with this lib. It seems it's caused by `pyeda` and `screen` dependencies in `requirements.txt`.

Changes:
- Switch to debian bookworm to fix missing packages errors