### PR TITLE
fix: log bundle permissions for Apache when uploaded via SCP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,10 +111,11 @@ WORKDIR /app/bublik
 FROM base AS log-server
 
 RUN apt-get update && apt-get install -y \
-  apache2 \
-  file \
-  jq \
-  && rm -rf /var/lib/apt/lists/*
+    apache2 \
+    file \
+    jq \
+    inotify-tools \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN a2enmod cgid
 


### PR DESCRIPTION
When transferring log bundles to the logs folder using `scp`, the files are created with read-only permissions. Apache requires both read and execute permissions to access these files, so although logs are imported successfully, Apache cannot serve them correctly. As a result, fetching `.json` files fails in the Bublik UI.

This change starts a background process inside the Docker container that fixes permissions on newly added files and directories, ensuring Apache can properly serve the logs. By default, users in the `www-data` group are allowed to upload log bundles via `scp`.