### PR TITLE
fix(celery): pin worker prefetch multiplier to 1

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -191,7 +191,7 @@ services:
         - URL_PREFIX=${URL_PREFIX}
         - DOCS_URL=${DOCS_URL}
     command: >
-      watchfiles --filter python 'celery -A ${CELERY_APP} worker --max-tasks-per-child ${CELERYD_MAX_TASKS_PER_CHILD} --concurrency 1 -l ${CELERY_LOG_LEVEL}'
+      watchfiles --filter python 'celery -A ${CELERY_APP} worker --max-tasks-per-child ${CELERYD_MAX_TASKS_PER_CHILD} --concurrency 1 --prefetch-multiplier 1 -l ${CELERY_LOG_LEVEL}'
     entrypoint: ./entrypoint-celery.sh
     depends_on:
       - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,7 +174,7 @@ services:
 
   celery:
     image: ${DOCKER_REGISTRY:-ghcr.io}/${DOCKER_ORG:-ts-factory}/${RUNNER_IMAGE_NAME:-bublik-runner}:${IMAGE_TAG:-latest}
-    command: celery -A ${CELERY_APP} worker --max-tasks-per-child ${CELERYD_MAX_TASKS_PER_CHILD} --concurrency 1 -l ${CELERY_LOG_LEVEL}
+    command: celery -A ${CELERY_APP} worker --max-tasks-per-child ${CELERYD_MAX_TASKS_PER_CHILD} --concurrency 1 --prefetch-multiplier 1 -l ${CELERY_LOG_LEVEL}
     restart: unless-stopped
     environment:
       - BUBLIK_DOCKER_PROXY_PORT=${BUBLIK_DOCKER_PROXY_PORT}


### PR DESCRIPTION
With --concurrency 1 the worker still prefetched Celery's default of 4 messages, firing task_received ('started processing import') on up to 4 reserved tasks while only one actually ran. That made imports look like several run in parallel. Reserve only the running task so the status and event-log semantics reflect the real one-at-a-time execution.