### PR TITLE
fix(build): fix memory leak on low RAM systems

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ env:
   LOG_SERVER_IMAGE_NAME: bublik-log-server
   # Add your URL prefix here if you host with base url
   URL_PREFIX: ""
+  SOURCE_MAP: "true"
 
 jobs:
   build:
@@ -111,6 +112,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: |
             URL_PREFIX=${{ env.URL_PREFIX }}
+            SOURCE_MAP=${{ env.SOURCE_MAP }}
           push: true
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -22,7 +22,12 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 
 COPY ./bublik-ui ./
 
-RUN BASE_URL="$URL_PREFIX/v2" nx run bublik:build --base="$URL_PREFIX/v2" --sourcemap="true"
+ARG SOURCE_MAP=""
+
+RUN BASE_URL="$URL_PREFIX/v2" \
+    nx run bublik:build \
+    --base="$URL_PREFIX/v2" \
+    ${SOURCE_MAP:+--sourcemap=true}
 
 FROM nginx:1.27-alpine
 


### PR DESCRIPTION
Problem:
When running `task build` command a lot of the time it's run inside VM which might have limited memory so node fails to build.

Solution:
By default don't pass `--sourcemap=true` flag for creating UI sourcemaps which take a lot of RAM to produce so it builds without sourcemaps by default and in production builds it builds with it for debugging.