### PR TITLE
fix: [nginx] preserve original `X-Forwarded-Proto` for proxied requests

### DIFF
--- a/nginx/templates/prod/nginx.conf.template
+++ b/nginx/templates/prod/nginx.conf.template
@@ -19,6 +19,11 @@ map $http_upgrade $connection_upgrade {
     ''      close;
 }
 
+map $http_x_forwarded_proto $forwarded_proto {
+    default $http_x_forwarded_proto;
+    ""      $scheme;
+}
+
 server {
     listen ${BUBLIK_DOCKER_PROXY_PORT};
     large_client_header_buffers 16 5120k;
@@ -42,10 +47,12 @@ server {
 
     location ${URL_PREFIX}/ {
         proxy_pass http://django;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
         proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
+
         proxy_redirect off;
     }
 


### PR DESCRIPTION
When running behind Traefik, requests reach the internal Nginx proxy over HTTP even if the client connected via HTTPS.

The previous configuration overwrote the `X-Forwarded-Proto` header with `$scheme`, causing Django to always receive `http` as the request protocol.

This resulted in Django generating HTTP absolute URLs and failing URL validation for requests that originated over HTTPS (for example, the URL shortener endpoint expected an `https://` prefix but built an `http://` prefix instead).

Introduce a `forwarded_proto` map that preserves the incoming `X-Forwarded-Proto` header when it is already present, falling back to `$scheme` only when no upstream proxy has supplied the header.

Update the Django proxy configuration to forward this value instead of overwriting it. This ensures the original client protocol is preserved through the proxy chain while remaining compatible with deployments that are not behind an upstream reverse proxy.