### PR TITLE
fix: persist analytics in Docker volume

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,7 +93,7 @@ DB_USER=bublik
 
 # Optional anonymous analytics (disabled by default)
 ANALYTICS_ENABLED=False
-ANALYTICS_DB_PATH=/app/bublik/logs/analytics.sqlite3
+ANALYTICS_DB_PATH=/app/bublik/analytics/analytics.sqlite3
 
 EMAIL_ADMINS=admin@bublik.com
 EMAIL_FROM=admin@bublik.com

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -35,7 +35,7 @@ services:
       - DB_PASSWORD=${DB_PASSWORD}
       - DB_PORT=${DB_PORT}
       - ANALYTICS_ENABLED=${ANALYTICS_ENABLED:-False}
-      - ANALYTICS_DB_PATH=${ANALYTICS_DB_PATH:-/app/bublik/logs/analytics.sqlite3}
+      - ANALYTICS_DB_PATH=/app/bublik/analytics/analytics.sqlite3
       - CELERY_APP=${CELERY_APP}
       - CELERY_RESULT_BACKEND=${CELERY_RESULT_BACKEND}
       - CELERY_ACCEPT_CONTENT=${CELERY_ACCEPT_CONTENT}
@@ -120,7 +120,7 @@ services:
       - DB_PASSWORD=${DB_PASSWORD}
       - DB_PORT=${DB_PORT}
       - ANALYTICS_ENABLED=${ANALYTICS_ENABLED:-False}
-      - ANALYTICS_DB_PATH=${ANALYTICS_DB_PATH:-/app/bublik/logs/analytics.sqlite3}
+      - ANALYTICS_DB_PATH=/app/bublik/analytics/analytics.sqlite3
       - CELERY_APP=${CELERY_APP}
       - CELERY_RESULT_BACKEND=${CELERY_RESULT_BACKEND}
       - CELERY_ACCEPT_CONTENT=${CELERY_ACCEPT_CONTENT}
@@ -152,6 +152,7 @@ services:
     volumes:
       - static_data:/app/bublik/bublik/representation/static
       - ${BUBLIK_DOCKER_DATA_DIR}/django-logs:/app/bublik/logs
+      - analytics_data:/app/bublik/analytics
     develop:
       watch:
         - path: ./bublik
@@ -220,7 +221,7 @@ services:
       - DB_PASSWORD=${DB_PASSWORD}
       - DB_PORT=${DB_PORT}
       - ANALYTICS_ENABLED=${ANALYTICS_ENABLED:-False}
-      - ANALYTICS_DB_PATH=${ANALYTICS_DB_PATH:-/app/bublik/logs/analytics.sqlite3}
+      - ANALYTICS_DB_PATH=/app/bublik/analytics/analytics.sqlite3
       - CELERY_APP=${CELERY_APP}
       - CELERY_RESULT_BACKEND=${CELERY_RESULT_BACKEND}
       - CELERY_ACCEPT_CONTENT=${CELERY_ACCEPT_CONTENT}
@@ -285,7 +286,7 @@ services:
       - DB_PASSWORD=${DB_PASSWORD}
       - DB_PORT=${DB_PORT}
       - ANALYTICS_ENABLED=${ANALYTICS_ENABLED:-False}
-      - ANALYTICS_DB_PATH=${ANALYTICS_DB_PATH:-/app/bublik/logs/analytics.sqlite3}
+      - ANALYTICS_DB_PATH=/app/bublik/analytics/analytics.sqlite3
       - CELERY_APP=${CELERY_APP}
       - CELERY_RESULT_BACKEND=${CELERY_RESULT_BACKEND}
       - CELERY_ACCEPT_CONTENT=${CELERY_ACCEPT_CONTENT}
@@ -438,6 +439,7 @@ services:
       - URL_PREFIX=${URL_PREFIX}
 
 volumes:
+  analytics_data:
   db_data:
   flower_data:
   static_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - DB_PASSWORD=${DB_PASSWORD}
       - DB_PORT=${DB_PORT}
       - ANALYTICS_ENABLED=${ANALYTICS_ENABLED:-False}
-      - ANALYTICS_DB_PATH=${ANALYTICS_DB_PATH:-/app/bublik/logs/analytics.sqlite3}
+      - ANALYTICS_DB_PATH=/app/bublik/analytics/analytics.sqlite3
       - CELERY_APP=${CELERY_APP}
       - CELERY_RESULT_BACKEND=${CELERY_RESULT_BACKEND}
       - CELERY_ACCEPT_CONTENT=${CELERY_ACCEPT_CONTENT}
@@ -108,7 +108,7 @@ services:
       - DB_PASSWORD=${DB_PASSWORD}
       - DB_PORT=${DB_PORT}
       - ANALYTICS_ENABLED=${ANALYTICS_ENABLED:-False}
-      - ANALYTICS_DB_PATH=${ANALYTICS_DB_PATH:-/app/bublik/logs/analytics.sqlite3}
+      - ANALYTICS_DB_PATH=/app/bublik/analytics/analytics.sqlite3
       - CELERY_APP=${CELERY_APP}
       - CELERY_RESULT_BACKEND=${CELERY_RESULT_BACKEND}
       - CELERY_ACCEPT_CONTENT=${CELERY_ACCEPT_CONTENT}
@@ -138,6 +138,7 @@ services:
       - redis
     volumes:
       - ${BUBLIK_DOCKER_DATA_DIR}/django-logs:/app/bublik/logs
+      - analytics_data:/app/bublik/analytics
       - static_data:/app/bublik/bublik/representation/static
     healthcheck:
       test:
@@ -198,7 +199,7 @@ services:
       - DB_PASSWORD=${DB_PASSWORD}
       - DB_PORT=${DB_PORT}
       - ANALYTICS_ENABLED=${ANALYTICS_ENABLED:-False}
-      - ANALYTICS_DB_PATH=${ANALYTICS_DB_PATH:-/app/bublik/logs/analytics.sqlite3}
+      - ANALYTICS_DB_PATH=/app/bublik/analytics/analytics.sqlite3
       - CELERY_APP=${CELERY_APP}
       - CELERY_RESULT_BACKEND=${CELERY_RESULT_BACKEND}
       - CELERY_ACCEPT_CONTENT=${CELERY_ACCEPT_CONTENT}
@@ -262,7 +263,7 @@ services:
       - DB_PASSWORD=${DB_PASSWORD}
       - DB_PORT=${DB_PORT}
       - ANALYTICS_ENABLED=${ANALYTICS_ENABLED:-False}
-      - ANALYTICS_DB_PATH=${ANALYTICS_DB_PATH:-/app/bublik/logs/analytics.sqlite3}
+      - ANALYTICS_DB_PATH=/app/bublik/analytics/analytics.sqlite3
       - CELERY_APP=${CELERY_APP}
       - CELERY_RESULT_BACKEND=${CELERY_RESULT_BACKEND}
       - CELERY_ACCEPT_CONTENT=${CELERY_ACCEPT_CONTENT}
@@ -366,6 +367,7 @@ services:
       start_period: 10s
 
 volumes:
+  analytics_data:
   static_data:
   flower_data:
   redis_data:

--- a/docker-settings.py.template
+++ b/docker-settings.py.template
@@ -64,7 +64,7 @@ INSTALLED_APPS = [
 ]
 
 ANALYTICS_ENABLED = os.getenv('ANALYTICS_ENABLED', '0').lower() in ('1', 'true', 'yes')
-ANALYTICS_DB_PATH = os.getenv('ANALYTICS_DB_PATH', '/app/bublik/logs/analytics.sqlite3')
+ANALYTICS_DB_PATH = os.getenv('ANALYTICS_DB_PATH', '/app/bublik/analytics/analytics.sqlite3')
 
 if ANALYTICS_ENABLED:
     INSTALLED_APPS.append('bublik.analytics')

--- a/entrypoint-common.sh
+++ b/entrypoint-common.sh
@@ -27,6 +27,20 @@ setup_permissions() {
     done
 }
 
+setup_runtime_permissions() {
+    local uid=${HOST_UID:-1000}
+    local gid=${HOST_GID:-1000}
+
+    for dir in "$@"; do
+        if [ -d "$dir" ]; then
+            echo "Setting up runtime permissions for $dir"
+            chown -R "${uid}:${gid}" "$dir"
+            chmod -R 2775 "$dir"
+            find "$dir" -type f -exec chmod 664 {} \; 2>/dev/null || true
+        fi
+    done
+}
+
 exec_as_user() {
     if [ "$(id -u)" -eq 0 ]; then
         CONTAINER_UID=${HOST_UID:-1000}

--- a/entrypoint-django.sh
+++ b/entrypoint-django.sh
@@ -5,8 +5,10 @@ source /app/bublik/entrypoint-common.sh
 setup_umask
 
 echo "Setting up required directories..."
+ANALYTICS_DB_DIR="$(dirname "${ANALYTICS_DB_PATH:-/app/bublik/analytics/analytics.sqlite3}")"
 ensure_directory "${BUBLIK_LOGDIR}"
 ensure_directory "/app/bublik/logs"
+ensure_directory "${ANALYTICS_DB_DIR}"
 ensure_directory "${BUBLIK_DOCKER_DATA_DIR}/django-logs"
 ensure_directory "${BUBLIK_DOCKER_DATA_DIR}/te-logs/logs"
 ensure_directory "${BUBLIK_DOCKER_DATA_DIR}/te-logs/incoming"
@@ -45,5 +47,7 @@ if not User.objects.filter(email=SUPERUSER_EMAIL).exists():
 else:
     print(f'Superuser with email {SUPERUSER_EMAIL} already exists.')
 EOF
+
+setup_runtime_permissions "${ANALYTICS_DB_DIR}"
 
 exec_as_user "$@" 


### PR DESCRIPTION
Move the SQLite analytics database out of the logs bind mount and into a named Docker volume for production and development deployments. Use a fixed in-container path so local environment overrides cannot redirect analytics back onto the filesystem, and normalize volume ownership to HOST_UID:HOST_GID after migrations so the unprivileged Django process can write SQLite journal files without permission errors.